### PR TITLE
Expose the vanilla JWT function and not the thunkified ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,6 @@ module.exports = function(opts) {
 };
 
 // Export JWT methods as a convenience
-module.exports.sign   = JWT.sign;
-module.exports.verify = JWT.verify;
-module.exports.decode = JWT.decode;
+module.exports.sign   = _JWT.sign;
+module.exports.verify = _JWT.verify;
+module.exports.decode = _JWT.decode;


### PR DESCRIPTION
Basically exposes `JWT` package function as-is, without thunkification. Avoids surprises.