### PR TITLE
Add support for koa-unless

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,40 @@ app.listen(3000);
 ```
 
 
-Alternatively, you can add the `passthrough` option to always yield next,
+Alternatively you can conditionally run the `jwt` middleware under certain conditions:
+
+```js
+var koa = require('koa');
+var jwt = require('koa-jwt');
+
+var app = koa();
+
+// Middleware below this line is only reached if JWT token is valid
+// unless the URL starts with '/public'
+app.use(jwt({ secret: 'shared-secret' }).unless({ path: [/^\/public/] }));
+
+// Unprotected middleware
+app.use(function *(next){
+  if (this.url.match(/^\/public/)) {
+    this.body = 'unprotected\n';
+  } else {
+    yield next;
+  }
+});
+
+// Protected middleware
+app.use(function *(){
+  if (this.url.match(/^\/api/)) {
+    this.body = 'protected\n';
+  }
+});
+
+app.listen(3000);
+```
+
+For more information on `unless` exceptions, check [koa-unless](https://github.com/Foxandxss/koa-unless).
+
+You can also add the `passthrough` option to always yield next,
 even if no valid Authorization header was found:
 ```js
 app.use(jwt({ secret: 'shared-secret', passthrough: true }));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var assert   = require('assert');
 var thunkify = require('thunkify');
-var _JWT      = require('jsonwebtoken');
+var _JWT     = require('jsonwebtoken');
+var unless   = require('koa-unless');
 
 // Make verify function play nice with co/koa
 var JWT = {decode: _JWT.decode, sign: _JWT.sign, verify: thunkify(_JWT.verify)};
@@ -11,7 +12,7 @@ module.exports = function(opts) {
 
   assert(opts.secret, '"secret" option is required');
 
-  return function *jwt(next) {
+  var middleware = function *jwt(next) {
     var token, msg, user, parts, scheme, credentials;
 
     if (this.header.authorization) {
@@ -48,6 +49,10 @@ module.exports = function(opts) {
       this.throw(401, msg);
     }
   };
+
+  middleware.unless = unless;
+
+  return middleware;
 };
 
 // Export JWT methods as a convenience

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "main": "./lib",
   "dependencies": {
     "jsonwebtoken": "~5.0.0",
+    "koa-unless": "0.0.1",
     "thunkify": "~2.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello @stiang and @citius.

As an alternative to #17 I created this PR using `koa-unless`.

This is what `express-jwt` does and I think it is more complete.

It allows you to conditionally run `koa-jwt`. You could skip it for certain URL, certain extensions or even provide a custom exception.

What do you think? :+1: 