### PR TITLE
add option to use token from a specific cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ module.exports = function(opts) {
   var middleware = function *jwt(next) {
     var token, msg, user, parts, scheme, credentials;
 
-    if (this.header.authorization) {
+    if (opts.cookie && this.cookies.get(opts.cookie)) {
+      token = this.cookies.get(opts.cookie);
+
+    } else if (this.header.authorization) {
       parts = this.header.authorization.split(' ');
       if (parts.length == 2) {
         scheme = parts[0];


### PR DESCRIPTION
Using a HTTPS cookie in which to store the token may seem counter-intuitive, as sometimes the desire to use Auth headers is to move away from cookies. HTTPS cookies however, cannot be inspected from Javascript, whereas setting an Auth header from a front-end app must use some Javascript. So, storing the JWT in a HTTPS cookie can be safer as malicious Javascript is unable to steal the token so easily as if it is used somewhere in the code.

This pull request adds an option, under opts.cookie, which specifies the name of a cookie that can be the source of the JWT in addition to or instead of the Auth header.